### PR TITLE
Tatar Translation Tweak.

### DIFF
--- a/common/src/main/resources/assets/cherishedworlds/lang/tt_ru.json
+++ b/common/src/main/resources/assets/cherishedworlds/lang/tt_ru.json
@@ -1,5 +1,5 @@
 {
-  "modmenu.descriptionTranslation.cherishedworlds": "һәрвакыт исемлекнең өске өлешендә була торган һәм бетерергә мөмкин булмаган билгеле дөньяларны сайланмаларга/кыстыргычларга өстәгез/беркетегез.",
+  "modmenu.descriptionTranslation.cherishedworlds": "Һәрвакыт исемлекнең өске өлешендә була торган һәм бетерергә мөмкин булмаган билгеле дөньяларны сайланмаларга/кыстыргычларга өстәгез/беркетегез.",
   "selectWorld.cherishedworlds.favorite": "Сайланмаларга өстәү",
   "selectWorld.cherishedworlds.unfavorite": "Сайланмалардан бетерү"
 }


### PR DESCRIPTION
Yeah... the first letter of the first word in sentence should be capitalized.