### PR TITLE
Update Minecraft to 26.1 and Java to 25

### DIFF
--- a/common/build.gradle
+++ b/common/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'multiloader-common'
-    id 'net.neoforged.moddev' version '2.0.123'
+    id 'net.neoforged.moddev' version '2.0.141'
 }
 
 neoForge {
@@ -10,10 +10,6 @@ neoForge {
     if (at.exists()) {
         accessTransformers.from(at.absolutePath)
     }
-    parchment {
-        minecraftVersion = parchment_mc
-        mappingsVersion = parchment_version
-    }
 }
 
 dependencies {
@@ -21,7 +17,7 @@ dependencies {
     // fabric and neoforge both bundle mixinextras, so it is safe to use it in common
     compileOnly group: 'io.github.llamalad7', name: 'mixinextras-common', version: '0.3.5'
     annotationProcessor group: 'io.github.llamalad7', name: 'mixinextras-common', version: '0.3.5'
-    implementation group: 'com.illusivesoulworks.spectrelib', name: 'spectrelib-common', version: "${spectrelib_version}"
+    compileOnly group: 'com.illusivesoulworks.spectrelib', name: 'spectrelib-common', version: "${spectrelib_version}"
 }
 
 configurations {

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/client/ScreenEvents.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/client/ScreenEvents.java
@@ -21,7 +21,7 @@ import com.illusivesoulworks.cherishedworlds.client.favorites.FavoriteCreateWorl
 import com.illusivesoulworks.cherishedworlds.client.favorites.FavoriteServers;
 import com.illusivesoulworks.cherishedworlds.client.favorites.FavoriteWorlds;
 import com.illusivesoulworks.cherishedworlds.platform.Services;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.multiplayer.JoinMultiplayerScreen;
 import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
@@ -37,7 +37,8 @@ public class ScreenEvents {
     CREATE_WORLD.saveFavorite(levelId);
   }
 
-  public static void onDraw(int mouseX, int mouseY, GuiGraphics guiGraphics, Screen screen) {
+  public static void onDraw(int mouseX, int mouseY, GuiGraphicsExtractor guiGraphics,
+                            Screen screen) {
 
     if (Services.PLATFORM.canRender()) {
 

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/client/favorites/FavoriteCreateWorld.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/client/favorites/FavoriteCreateWorld.java
@@ -1,6 +1,6 @@
 package com.illusivesoulworks.cherishedworlds.client.favorites;
 
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.worldselection.CreateWorldScreen;
 
 public class FavoriteCreateWorld implements IFavoritesViewer<CreateWorldScreen> {
@@ -13,7 +13,8 @@ public class FavoriteCreateWorld implements IFavoritesViewer<CreateWorldScreen> 
   }
 
   @Override
-  public void draw(int mouseX, int mouseY, GuiGraphics guiGraphics, CreateWorldScreen screen) {
+  public void draw(int mouseX, int mouseY, GuiGraphicsExtractor guiGraphics,
+                   CreateWorldScreen screen) {
     drawIcon(mouseX, mouseY, guiGraphics, screen, 0, isFavorited, screen.height - 35, 0,
         screen.height + 25);
   }

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/client/favorites/FavoriteServers.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/client/favorites/FavoriteServers.java
@@ -20,7 +20,7 @@ package com.illusivesoulworks.cherishedworlds.client.favorites;
 import com.illusivesoulworks.cherishedworlds.integration.ViewerIntegration;
 import com.illusivesoulworks.cherishedworlds.mixin.core.AccessorJoinMultiplayerScreen;
 import com.mojang.datafixers.util.Pair;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.screens.multiplayer.JoinMultiplayerScreen;
 import net.minecraft.client.gui.screens.multiplayer.ServerSelectionList;
@@ -34,7 +34,8 @@ public class FavoriteServers implements IFavoritesViewer<JoinMultiplayerScreen> 
   }
 
   @Override
-  public void draw(int mouseX, int mouseY, GuiGraphics guiGraphics, JoinMultiplayerScreen screen) {
+  public void draw(int mouseX, int mouseY, GuiGraphicsExtractor guiGraphics,
+                   JoinMultiplayerScreen screen) {
     AccessorJoinMultiplayerScreen accessor = (AccessorJoinMultiplayerScreen) screen;
     ServerSelectionList selectionList = accessor.getSelectionList();
 

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/client/favorites/FavoriteWorlds.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/client/favorites/FavoriteWorlds.java
@@ -22,7 +22,7 @@ import com.illusivesoulworks.cherishedworlds.mixin.core.AccessorWorldSelectionLi
 import com.illusivesoulworks.cherishedworlds.mixin.core.AccessorWorldSelectionScreen;
 import com.mojang.datafixers.util.Pair;
 import java.util.List;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.components.Button;
 import net.minecraft.client.gui.components.EditBox;
 import net.minecraft.client.gui.screens.worldselection.SelectWorldScreen;
@@ -46,7 +46,8 @@ public class FavoriteWorlds implements IFavoritesViewer<SelectWorldScreen> {
   }
 
   @Override
-  public void draw(int mouseX, int mouseY, GuiGraphics guiGraphics, SelectWorldScreen screen) {
+  public void draw(int mouseX, int mouseY, GuiGraphicsExtractor guiGraphics,
+                   SelectWorldScreen screen) {
     AccessorWorldSelectionScreen accessor = (AccessorWorldSelectionScreen) screen;
     WorldSelectionList selectionList = accessor.getList();
 

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/client/favorites/IFavoritesViewer.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/client/favorites/IFavoritesViewer.java
@@ -23,7 +23,7 @@ import com.mojang.datafixers.util.Pair;
 import java.util.ArrayList;
 import java.util.List;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.GuiGraphicsExtractor;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.client.gui.screens.inventory.tooltip.ClientTooltipComponent;
 import net.minecraft.client.gui.screens.inventory.tooltip.DefaultTooltipPositioner;
@@ -43,7 +43,7 @@ public interface IFavoritesViewer<T extends Screen> {
 
   void init(T screen);
 
-  void draw(int mouseX, int mouseY, GuiGraphics guiGraphics, T screen);
+  void draw(int mouseX, int mouseY, GuiGraphicsExtractor guiGraphics, T screen);
 
   void click(int mouseX, int mouseY, T screen);
 
@@ -51,7 +51,8 @@ public interface IFavoritesViewer<T extends Screen> {
 
   int getHorizontalOffset();
 
-  default void drawIcon(int mouseX, int mouseY, GuiGraphics guiGraphics, T screen, int index,
+  default void drawIcon(int mouseX, int mouseY, GuiGraphicsExtractor guiGraphics, T screen,
+                        int index,
                         boolean isFavorite, int topOffset, double scrollAmount, int bottom) {
     Identifier icon = isFavorite ? STAR_ICON : EMPTY_STAR_ICON;
     int topOffsetMod = 15;
@@ -75,8 +76,8 @@ public interface IFavoritesViewer<T extends Screen> {
       MutableComponent component =
           Component.translatable("selectWorld." + CherishedWorldsConstants.MOD_ID + "." + suffix);
       components.add(ClientTooltipComponent.create(component.getVisualOrderText()));
-      guiGraphics.renderTooltip(Minecraft.getInstance().font, components, mouseX, mouseY,
-                                DefaultTooltipPositioner.INSTANCE, null);
+      guiGraphics.tooltip(Minecraft.getInstance().font, components, mouseX, mouseY,
+                          DefaultTooltipPositioner.INSTANCE, null);
     }
   }
 }

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/core/MixinWorldOpenFlows.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/core/MixinWorldOpenFlows.java
@@ -4,13 +4,15 @@ import com.illusivesoulworks.cherishedworlds.client.ScreenEvents;
 import com.illusivesoulworks.cherishedworlds.mixin.CherishedWorldsMixinHooks;
 import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
 import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import java.util.Optional;
 import net.minecraft.client.gui.screens.worldselection.WorldOpenFlows;
 import net.minecraft.core.LayeredRegistryAccess;
 import net.minecraft.server.RegistryLayer;
 import net.minecraft.server.ReloadableServerResources;
+import net.minecraft.world.level.gamerules.GameRules;
+import net.minecraft.world.level.storage.LevelDataAndDimensions;
 import net.minecraft.world.level.storage.LevelStorageSource;
 import net.minecraft.world.level.storage.LevelSummary;
-import net.minecraft.world.level.storage.WorldData;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -35,7 +37,9 @@ public class MixinWorldOpenFlows {
       method = "createLevelFromExistingSettings")
   private void cherishedworlds$createLevelFromExistingSettings(
       LevelStorageSource.LevelStorageAccess levelStorageAccess, ReloadableServerResources unused,
-      LayeredRegistryAccess<RegistryLayer> unused1, WorldData unused2, CallbackInfo ci) {
+      LayeredRegistryAccess<RegistryLayer> unused1,
+      LevelDataAndDimensions.WorldDataAndGenSettings unused2, Optional<GameRules> unused3,
+      CallbackInfo ci) {
     ScreenEvents.onCreateNewWorld(levelStorageAccess.getLevelId());
   }
 }

--- a/common/src/main/resources/cherishedworlds.mixins.json
+++ b/common/src/main/resources/cherishedworlds.mixins.json
@@ -2,7 +2,7 @@
   "required": true,
   "minVersion": "0.8",
   "package": "com.illusivesoulworks.cherishedworlds.mixin.core",
-  "compatibilityLevel": "JAVA_21",
+  "compatibilityLevel": "JAVA_25",
   "mixins": [
   ],
   "client": [

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -2,22 +2,18 @@ import net.darkhax.curseforgegradle.TaskPublishCurseForge
 
 plugins {
     id 'multiloader-loader'
-    id 'fabric-loom' version '1.13-SNAPSHOT'
+    id 'net.fabricmc.fabric-loom' version "${loom_version}"
     id 'com.modrinth.minotaur' version '2.+'
     id 'net.darkhax.curseforgegradle' version '1.+'
 }
 dependencies {
     minecraft "com.mojang:minecraft:${minecraft_version}"
-    mappings loom.layered() {
-        officialMojangMappings()
-        parchment("org.parchmentmc.data:parchment-${parchment_mc}:${parchment_version}@zip")
-    }
-    modImplementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
+    implementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
+    implementation "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
 
-    modCompileOnly "curse.maven:fancymenu-367706:5319783"
+    compileOnly "curse.maven:fancymenu-367706:5319783"
 
-    modImplementation "com.illusivesoulworks.spectrelib:spectrelib-fabric:${spectrelib_version}"
+    implementation "com.illusivesoulworks.spectrelib:spectrelib-fabric:${spectrelib_version}"
     include "com.illusivesoulworks.spectrelib:spectrelib-fabric:${spectrelib_version}"
 }
 

--- a/fabric/src/main/java/com/illusivesoulworks/cherishedworlds/CherishedWorldsFabricMod.java
+++ b/fabric/src/main/java/com/illusivesoulworks/cherishedworlds/CherishedWorldsFabricMod.java
@@ -37,7 +37,7 @@ public class CherishedWorldsFabricMod implements ClientModInitializer {
           if (screen instanceof JoinMultiplayerScreen || screen instanceof SelectWorldScreen ||
               screen instanceof CreateWorldScreen) {
             com.illusivesoulworks.cherishedworlds.client.ScreenEvents.onInit(screen);
-            ScreenEvents.afterRender(screen).register(
+            ScreenEvents.afterExtract(screen).register(
                 (screen1, drawContext, mouseX, mouseY, tickDelta) -> com.illusivesoulworks.cherishedworlds.client.ScreenEvents.onDraw(
                     mouseX, mouseY, drawContext, screen1));
             ScreenMouseEvents.afterMouseClick(screen).register(

--- a/fabric/src/main/java/com/illusivesoulworks/cherishedworlds/integration/FancyMenuIntegration.java
+++ b/fabric/src/main/java/com/illusivesoulworks/cherishedworlds/integration/FancyMenuIntegration.java
@@ -1,12 +1,21 @@
 package com.illusivesoulworks.cherishedworlds.integration;
 
-import de.keksuccino.fancymenu.customization.overlay.CustomizationOverlay;
-import de.keksuccino.fancymenu.customization.overlay.CustomizationOverlayMenuBar;
-
 public class FancyMenuIntegration {
 
   public static boolean isNavigating() {
-    CustomizationOverlayMenuBar menuBar = CustomizationOverlay.getCurrentMenuBarInstance();
-    return menuBar != null && menuBar.isEntryContextMenuOpen();
+    try {
+      Class<?> customizationOverlayClass =
+          Class.forName("de.keksuccino.fancymenu.customization.overlay.CustomizationOverlay");
+      Object menuBar = customizationOverlayClass.getMethod("getCurrentMenuBarInstance")
+          .invoke(null);
+
+      if (menuBar == null) {
+        return false;
+      }
+      Object result = menuBar.getClass().getMethod("isEntryContextMenuOpen").invoke(menuBar);
+      return result instanceof Boolean && (Boolean) result;
+    } catch (ReflectiveOperationException | LinkageError ex) {
+      return false;
+    }
   }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -26,7 +26,7 @@
     "${mod_id}.mixins.json"
   ],
   "depends": {
-    "fabricloader": ">=0.15",
+    "fabricloader": ">=0.19.0",
     "fabric-api": "*",
     "minecraft": "${minecraft_version_range_alt}",
     "java": ">=${java_version}"

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -2,78 +2,51 @@ import net.darkhax.curseforgegradle.TaskPublishCurseForge
 
 plugins {
     id 'multiloader-loader'
-    id 'net.minecraftforge.gradle' version '[6.0.46,6.2)'
-    id 'org.spongepowered.mixin' version '0.7-SNAPSHOT'
+    id 'net.minecraftforge.gradle' version '[7.0.17,8)'
     id 'com.modrinth.minotaur' version '2.+'
     id 'net.darkhax.curseforgegradle' version '1.+'
 }
 
-mixin {
-    config("${mod_id}.mixins.json")
-}
-
 minecraft {
-    mappings channel: "official", version: "${minecraft_version}"
-    reobf = false
-    copyIdeResources = true
-
-    // Automatically enable forge AccessTransformers if the file exists
-    // This location is hardcoded in Forge and can not be changed.
-    // https://github.com/MinecraftForge/MinecraftForge/blob/be1698bb1554f9c8fa2f58e32b9ab70bc4385e60/fmlloader/src/main/java/net/minecraftforge/fml/loading/moddiscovery/ModFile.java#L123
-    def at = file('src/main/resources/META-INF/accesstransformer.cfg')
-    if (at.exists()) {
-        accessTransformer = at
-    }
-
     runs {
-        client {
-            workingDirectory file('runs/client')
-            ideaModule "${rootProject.name}.${project.name}.main"
-            taskName 'Client'
-            mods {
-                modClientRun {
-                    source sourceSets.main
-                }
-            }
+        configureEach {
+            workingDir = layout.projectDirectory.dir('runs/default')
+            systemProperty 'eventbus.api.strictRuntimeChecks', 'true'
+            systemProperty 'forge.enabledGameTestNamespaces', mod_id
         }
 
-        server {
-            workingDirectory file('runs/server')
-            ideaModule "${rootProject.name}.${project.name}.main"
-            taskName 'Server'
-            mods {
-                modServerRun {
-                    source sourceSets.main
-                }
-            }
+        register('client')
+
+        register('server') {
+            args '--nogui'
         }
 
-        data {
-            workingDirectory file('runs/data')
-            ideaModule "${rootProject.name}.${project.name}.main"
-            args '--mod', mod_id, '--all', '--output', file('src/generated/resources/'), '--existing', file('src/main/resources/')
-            taskName 'Data'
-            mods {
-                modDataRun {
-                    source sourceSets.main
-                }
-            }
+        register('gameTestServer')
+
+        register('data') {
+            workingDir = layout.projectDirectory.dir('runs/data')
+            args '--mod', mod_id, '--all', '--output', file('src/generated/resources/'), '--existing',
+                    file('src/main/resources/')
         }
     }
 }
 
 sourceSets.main.resources { srcDir 'src/generated/resources' }
 
+repositories {
+    minecraft.mavenizer(it)
+    maven fg.forgeMaven
+    maven fg.minecraftLibsMaven
+    mavenCentral()
+}
+
 dependencies {
-    minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
-    annotationProcessor("org.spongepowered:mixin:0.8.5-SNAPSHOT:processor")
+    implementation minecraft.dependency("net.minecraftforge:forge:${minecraft_version}-${forge_version}")
+    annotationProcessor 'net.minecraftforge:eventbus-validator:7.0.1'
 
     compileOnly "curse.maven:fancymenu-367706:5319786"
 
     implementation group: 'com.illusivesoulworks.spectrelib', name: 'spectrelib-forge', version: "${spectrelib_version}"
-    jarJar(group: 'com.illusivesoulworks.spectrelib', name: 'spectrelib-forge', version: "[0.16.1,2.0)") {
-        jarJar.pin(it, "${spectrelib_version}")
-    }
 }
 
 sourceSets.each {

--- a/forge/src/main/java/com/illusivesoulworks/cherishedworlds/integration/FancyMenuIntegration.java
+++ b/forge/src/main/java/com/illusivesoulworks/cherishedworlds/integration/FancyMenuIntegration.java
@@ -1,12 +1,21 @@
 package com.illusivesoulworks.cherishedworlds.integration;
 
-import de.keksuccino.fancymenu.customization.overlay.CustomizationOverlay;
-import de.keksuccino.fancymenu.customization.overlay.CustomizationOverlayMenuBar;
-
 public class FancyMenuIntegration {
 
   public static boolean isNavigating() {
-    CustomizationOverlayMenuBar menuBar = CustomizationOverlay.getCurrentMenuBarInstance();
-    return menuBar != null && menuBar.isEntryContextMenuOpen();
+    try {
+      Class<?> customizationOverlayClass =
+          Class.forName("de.keksuccino.fancymenu.customization.overlay.CustomizationOverlay");
+      Object menuBar = customizationOverlayClass.getMethod("getCurrentMenuBarInstance")
+          .invoke(null);
+
+      if (menuBar == null) {
+        return false;
+      }
+      Object result = menuBar.getClass().getMethod("isEntryContextMenuOpen").invoke(menuBar);
+      return result instanceof Boolean && (Boolean) result;
+    } catch (ReflectiveOperationException | LinkageError ex) {
+      return false;
+    }
   }
 }

--- a/forge/src/main/java/com/illusivesoulworks/cherishedworlds/platform/ForgePlatformHelper.java
+++ b/forge/src/main/java/com/illusivesoulworks/cherishedworlds/platform/ForgePlatformHelper.java
@@ -27,7 +27,7 @@ public class ForgePlatformHelper implements IPlatformHelper {
 
   @Override
   public boolean isModLoaded(String modId) {
-    return ModList.get().isLoaded(modId);
+    return ModList.isLoaded(modId);
   }
 
   @Override

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 # Project
-version=15.2.0+1.21.11
+version=15.3.0+26.1.2
 group=com.illusivesoulworks.cherishedworlds
-java_version=21
+java_version=25
 
 # Common
-minecraft_version=1.21.11
+minecraft_version=26.1.2
 mod_name=Cherished Worlds
 mod_author=Illusive Soulworks
 mod_id=cherishedworlds
@@ -12,31 +12,32 @@ license=LGPL-3.0-or-later
 issues_url=https://github.com/illusivesoulworks/cherishedworlds/issues
 sources_url=https://github.com/illusivesoulworks/cherishedworlds
 description=Favorite/pin/bookmark certain worlds, which will always be at the top of the list and cannot be deleted.
-minecraft_version_range=[1.21.11, 1.22)
-minecraft_version_range_alt=~1.21.11
+minecraft_version_range=[26.1, 26.1.2]
+minecraft_version_range_alt=>=26.1 <=26.1.2
 
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
-neo_form_version=1.21.11-20251209.172050
+neo_form_version=26.1.2-1
 
 # Parchment
-parchment_mc=1.21.10
-parchment_version=2025.10.12
+parchment_mc=26.1.2
+parchment_version=2026.03.30
 
 # SpectreLib
 spectrelib_version=0.20.2+1.21.11
 
 # Fabric
-fabric_version=0.140.2+1.21.11
-fabric_loader_version=0.18.2
+fabric_version=0.145.1+26.1
+fabric_loader_version=0.19.1
+loom_version=1.16-SNAPSHOT
 
 # Forge
-forge_version=61.0.3
-forge_version_range=[59,)
+forge_version=64.0.1
+forge_version_range=[64,)
 
 # NeoForge
-neoforge_version=21.11.17-beta
-neoforge_version_range=[21.9,)
+neoforge_version=26.1.2.7-beta
+neoforge_version_range=[26.1,)
 
 # Publishing Options
 cf_id=308240
@@ -44,8 +45,8 @@ cf_page=https://www.curseforge.com/minecraft/mc-mods/cherished-worlds
 modrinth_id=3azQ6p0W
 modrinth_page=https://modrinth.com/mod/cherished-worlds
 release_type=release
-release_versions=1.21.11
-changelog_link=https://github.com/illusivesoulworks/cherishedworlds/blob/1.21.x/CHANGELOG.md
+release_versions=26.1,26.1.1,26.1.2
+changelog_link=https://github.com/illusivesoulworks/cherishedworlds/blob/main/CHANGELOG.md
 discord_thumbnail=https://media.forgecdn.net/avatars/180/595/636793993834717165.png
 
 # Gradle

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.0-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -2,7 +2,7 @@ import net.darkhax.curseforgegradle.TaskPublishCurseForge
 
 plugins {
     id 'multiloader-loader'
-    id 'net.neoforged.moddev' version '2.0.123'
+    id 'net.neoforged.moddev' version '2.0.141'
     id 'com.modrinth.minotaur' version '2.+'
     id 'net.darkhax.curseforgegradle' version '1.+'
 }
@@ -10,11 +10,6 @@ plugins {
 neoForge {
     // Specify the version of NeoForge to use.
     version = project.neoforge_version
-
-    parchment {
-        mappingsVersion = project.parchment_version
-        minecraftVersion = project.parchment_mc
-    }
 
     runs {
         client {

--- a/neoforge/src/main/java/com/illusivesoulworks/cherishedworlds/integration/FancyMenuIntegration.java
+++ b/neoforge/src/main/java/com/illusivesoulworks/cherishedworlds/integration/FancyMenuIntegration.java
@@ -1,12 +1,21 @@
 package com.illusivesoulworks.cherishedworlds.integration;
 
-import de.keksuccino.fancymenu.customization.overlay.CustomizationOverlay;
-import de.keksuccino.fancymenu.customization.overlay.CustomizationOverlayMenuBar;
-
 public class FancyMenuIntegration {
 
   public static boolean isNavigating() {
-    CustomizationOverlayMenuBar menuBar = CustomizationOverlay.getCurrentMenuBarInstance();
-    return menuBar != null && menuBar.isEntryContextMenuOpen();
+    try {
+      Class<?> customizationOverlayClass =
+          Class.forName("de.keksuccino.fancymenu.customization.overlay.CustomizationOverlay");
+      Object menuBar = customizationOverlayClass.getMethod("getCurrentMenuBarInstance")
+          .invoke(null);
+
+      if (menuBar == null) {
+        return false;
+      }
+      Object result = menuBar.getClass().getMethod("isEntryContextMenuOpen").invoke(menuBar);
+      return result instanceof Boolean && (Boolean) result;
+    } catch (ReflectiveOperationException | LinkageError ex) {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
### Changed
- Updated Minecraft support range to [26.1, 26.1.2]
- Updated Java runtime version to 25
- Updated toolchain versions (Fabric, Forge, NeoForge) to maintain compatibility with Minecraft 26.1.x