### PR TITLE
Fix LAN server crash on Multiplayer screen [26.1.X]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 Prior to version 6.0.0, this project used MCVERSION-MAJORMOD.MAJORAPI.MINOR.PATCH.
 
+## [16.0.1+26.1.2] - 2026.07.06
+
+### Fixed
+- Fixed crash on multiplayer screen when a LAN server is detected
+
 ## [16.0.0+26.1.2] - 2026.04.28
 ### Added
 - Added accessibility features such as narration and key navigation

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/CherishedWorldsMixinHooks.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/CherishedWorldsMixinHooks.java
@@ -116,10 +116,6 @@ public class CherishedWorldsMixinHooks {
     onlineServers.clear();
     onlineServers.addAll(favorites);
     onlineServers.addAll(others);
-
-    for (int i = 0; i < onlineServers.size(); i++) {
-      servers.replace(i, onlineServers.get(i).getServerData());
-    }
   }
 
   public static void updateNetworkServers(List<LanServer> servers,
@@ -139,10 +135,6 @@ public class CherishedWorldsMixinHooks {
     onlineServers.clear();
     onlineServers.addAll(favorites);
     onlineServers.addAll(others);
-
-    for (int i = 0; i < onlineServers.size(); i++) {
-      servers.set(i, ((AccessorNetworkServerEntry) onlineServers.get(i)).getServerData());
-    }
   }
 
   public static Comparator<WorldSelectionList.Entry> getLevelComparator() {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project
-version=16.0.0+26.1.2
+version=16.0.1+26.1.2
 group=com.illusivesoulworks.cherishedworlds
 java_version=25
 


### PR DESCRIPTION
This PR addresses Issue https://github.com/illusivesoulworks/cherishedworlds/issues/59

causing Minecraft to crash when a LAN server is detected in the Multiplayer screen as Mojang made the LAN server list immutable.

In the case that Mojang makes online servers immutable, the PR also removes the backend reordering logic for online servers too. The visual changes to the UI are unchanged.

The mod version is also bumped to `16.0.1`.

