### PR TITLE
Update copyright to 2026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 Prior to version 6.0.0, this project used MCVERSION-MAJORMOD.MAJORAPI.MINOR.PATCH.
 
+## [16.0.1+26.1.2] - 2026.07.06
+
+### Fixed
+- Fixed crash on multiplayer screen when a LAN server is detected
+
 ## [16.0.0+26.1.2] - 2026.04.28
 ### Added
 - Added accessibility features such as narration and key navigation

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (C) 2018-2022 Illusive Soulworks
+Copyright (C) 2018-2026 Illusive Soulworks
 
 Cherished Worlds is free software: you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public License

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/CherishedWorldsCommonMod.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/CherishedWorldsCommonMod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/CherishedWorldsConstants.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/CherishedWorldsConstants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/client/ScreenEventHooks.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/client/ScreenEventHooks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/client/favorites/FavoritesList.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/client/favorites/FavoritesList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/client/favorites/impl/FavoriteServersWidget.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/client/favorites/impl/FavoriteServersWidget.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/CherishedWorldsMixinHooks.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/CherishedWorldsMixinHooks.java
@@ -116,10 +116,6 @@ public class CherishedWorldsMixinHooks {
     onlineServers.clear();
     onlineServers.addAll(favorites);
     onlineServers.addAll(others);
-
-    for (int i = 0; i < onlineServers.size(); i++) {
-      servers.replace(i, onlineServers.get(i).getServerData());
-    }
   }
 
   public static void updateNetworkServers(List<LanServer> servers,
@@ -139,10 +135,6 @@ public class CherishedWorldsMixinHooks {
     onlineServers.clear();
     onlineServers.addAll(favorites);
     onlineServers.addAll(others);
-
-    for (int i = 0; i < onlineServers.size(); i++) {
-      servers.set(i, ((AccessorNetworkServerEntry) onlineServers.get(i)).getServerData());
-    }
   }
 
   public static Comparator<WorldSelectionList.Entry> getLevelComparator() {

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/CherishedWorldsMixinHooks.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/CherishedWorldsMixinHooks.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/core/AccessorJoinMultiplayerScreen.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/core/AccessorJoinMultiplayerScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/core/AccessorWorldSelectionList.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/core/AccessorWorldSelectionList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/core/AccessorWorldSelectionScreen.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/core/AccessorWorldSelectionScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/core/MixinJoinMultiplayerScreen.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/core/MixinJoinMultiplayerScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/core/MixinManageServerScreen.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/core/MixinManageServerScreen.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/core/MixinServerSelectionList.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/core/MixinServerSelectionList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/core/MixinServerSelectionListEntry.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/core/MixinServerSelectionListEntry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/core/MixinWorldSelectionList.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/mixin/core/MixinWorldSelectionList.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/platform/Services.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/platform/Services.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/common/src/main/java/com/illusivesoulworks/cherishedworlds/platform/services/IPlatformHelper.java
+++ b/common/src/main/java/com/illusivesoulworks/cherishedworlds/platform/services/IPlatformHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/fabric/src/main/java/com/illusivesoulworks/cherishedworlds/CherishedWorldsFabricMod.java
+++ b/fabric/src/main/java/com/illusivesoulworks/cherishedworlds/CherishedWorldsFabricMod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/fabric/src/main/java/com/illusivesoulworks/cherishedworlds/platform/FabricPlatformHelper.java
+++ b/fabric/src/main/java/com/illusivesoulworks/cherishedworlds/platform/FabricPlatformHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/forge/src/main/java/com/illusivesoulworks/cherishedworlds/CherishedWorldsForgeMod.java
+++ b/forge/src/main/java/com/illusivesoulworks/cherishedworlds/CherishedWorldsForgeMod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/forge/src/main/java/com/illusivesoulworks/cherishedworlds/client/ScreenEventsListener.java
+++ b/forge/src/main/java/com/illusivesoulworks/cherishedworlds/client/ScreenEventsListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/forge/src/main/java/com/illusivesoulworks/cherishedworlds/platform/ForgePlatformHelper.java
+++ b/forge/src/main/java/com/illusivesoulworks/cherishedworlds/platform/ForgePlatformHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 # Project
-version=16.0.0+26.1.2
+version=16.0.1+26.1.2
 group=com.illusivesoulworks.cherishedworlds
 java_version=25
 

--- a/neoforge/src/main/java/com/illusivesoulworks/cherishedworlds/CherishedWorldsNeoForgeMod.java
+++ b/neoforge/src/main/java/com/illusivesoulworks/cherishedworlds/CherishedWorldsNeoForgeMod.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/neoforge/src/main/java/com/illusivesoulworks/cherishedworlds/client/ScreenEventsListener.java
+++ b/neoforge/src/main/java/com/illusivesoulworks/cherishedworlds/client/ScreenEventsListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published

--- a/neoforge/src/main/java/com/illusivesoulworks/cherishedworlds/platform/NeoForgePlatformHelper.java
+++ b/neoforge/src/main/java/com/illusivesoulworks/cherishedworlds/platform/NeoForgePlatformHelper.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2018-2022 Illusive Soulworks
+ * Copyright (C) 2018-2026 Illusive Soulworks
  *
  * Cherished Worlds is free software: you can redistribute it and/or modify it
  * under the terms of the GNU Lesser General Public License as published


### PR DESCRIPTION
This PR updates files that start with a copyright notice from 2022 to 2026. All functionality in files is left unchanged.