### PR TITLE
port: Minecraft 26.2 (Fabric + NeoForge)

### DIFF
--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -2,7 +2,7 @@ import net.darkhax.curseforgegradle.TaskPublishCurseForge
 
 plugins {
     id 'multiloader-loader'
-    id 'net.fabricmc.fabric-loom' version '1.16-SNAPSHOT'
+    id 'net.fabricmc.fabric-loom' version '1.17-SNAPSHOT'
     id 'com.modrinth.minotaur' version '2.+'
     id 'net.darkhax.curseforgegradle' version '1.+'
 }
@@ -11,7 +11,7 @@ dependencies {
     implementation "net.fabricmc:fabric-loader:${fabric_loader_version}"
     implementation "net.fabricmc.fabric-api:fabric-api:${fabric_version}"
 
-    compileOnly "curse.maven:fancymenu-367706:5319783"
+    compileOnly "curse.maven:fancymenu-367706:8440252"
 
     implementation "com.illusivesoulworks.spectrelib:spectrelib-fabric:${spectrelib_version}"
     include "com.illusivesoulworks.spectrelib:spectrelib-fabric:${spectrelib_version}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 # Project
-version=16.0.0+26.1.2
+version=16.0.0+26.2
 group=com.illusivesoulworks.cherishedworlds
 java_version=25
 
 # Common
-minecraft_version=26.1.2
+minecraft_version=26.2
 mod_name=Cherished Worlds
 mod_author=Illusive Soulworks
 mod_id=cherishedworlds
@@ -12,27 +12,27 @@ license=LGPL-3.0-or-later
 issues_url=https://github.com/illusivesoulworks/cherishedworlds/issues
 sources_url=https://github.com/illusivesoulworks/cherishedworlds
 description=Favorite/pin/bookmark certain worlds, which will always be at the top of the list and cannot be deleted.
-minecraft_version_range=[26.1,)
-minecraft_version_range_alt=~26.1
+minecraft_version_range=[26.2,)
+minecraft_version_range_alt=~26.2
 
 ## This is the version of minecraft that the 'common' project uses, you can find a list of all versions here
 ## https://projects.neoforged.net/neoforged/neoform
-neo_form_version=26.1.2-1
+neo_form_version=26.2-1
 
 # SpectreLib
-spectrelib_version=0.21.0+26.1.2
+spectrelib_version=0.22.0+26.2
 
 # Fabric
-fabric_version=0.146.1+26.1.2
-fabric_loader_version=0.19.2
+fabric_version=0.155.2+26.2
+fabric_loader_version=0.19.3
 
 # Forge
-forge_version=64.0.4
+forge_version=65.0.5
 forge_version_range=[62,)
 
 # NeoForge
-neoforge_version=26.1.2.22-beta
-neoforge_version_range=[26,)
+neoforge_version=26.2.0.23-beta
+neoforge_version_range=[26.2,)
 
 # Publishing Options
 cf_id=308240
@@ -40,7 +40,7 @@ cf_page=https://www.curseforge.com/minecraft/mc-mods/cherished-worlds
 modrinth_id=3azQ6p0W
 modrinth_page=https://modrinth.com/mod/cherished-worlds
 release_type=release
-release_versions=26.1.2,26.1.1,26.1
+release_versions=26.2
 changelog_link=https://github.com/illusivesoulworks/cherishedworlds/blob/26.x/CHANGELOG.md
 discord_thumbnail=https://media.forgecdn.net/avatars/180/595/636793993834717165.png
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/neoforge/build.gradle
+++ b/neoforge/build.gradle
@@ -52,10 +52,10 @@ configurations {
 sourceSets.main.resources { srcDir 'src/generated/resources' }
 
 dependencies {
-    compileOnly "curse.maven:fancymenu-367706:7896739"
-    runtimeOnly "curse.maven:fancymenu-367706:7896739"
-    runtimeOnly "curse.maven:konkrete-410295:7891762"
-    runtimeOnly "curse.maven:melody-938643:7875755"
+    compileOnly "curse.maven:fancymenu-367706:8440252"
+    runtimeOnly "curse.maven:fancymenu-367706:8440252"
+    runtimeOnly "curse.maven:konkrete-410295:8321892"
+    runtimeOnly "curse.maven:melody-938643:8316116"
 
     implementation group: 'com.illusivesoulworks.spectrelib', name: 'spectrelib-neoforge', version: "${spectrelib_version}"
     jarJar group: 'com.illusivesoulworks.spectrelib', name: 'spectrelib-neoforge', version: "${spectrelib_version}"

--- a/settings.gradle
+++ b/settings.gradle
@@ -38,12 +38,12 @@ pluginManagement {
 }
 
 plugins {
-    id 'org.gradle.toolchains.foojay-resolver-convention' version '0.10.0'
+    id 'org.gradle.toolchains.foojay-resolver-convention' version '1.0.0'
 }
 
 // This should match the folder name of the project, or else IDEA may complain (see https://youtrack.jetbrains.com/issue/IDEA-317606)
 rootProject.name = "${mod_id}"
 include("common")
 include("fabric")
-include("forge")
+//include("forge")
 include("neoforge")


### PR DESCRIPTION
Update all dependency versions for Minecraft 26.2 port:
- minecraft_version: 26.2
- neo_form_version: 26.2-1
- fabric_version: 0.155.2+26.2
- fabric_loader_version: 0.19.3
- forge_version: 65.0.5 (forge subproject disabled)
- neoforge_version: 26.2.0.23-beta
- spectrelib_version: 0.22.0+26.2
- loom: 1.17-SNAPSHOT
- gradle wrapper: 9.5.1
- foojay-resolver-convention: 1.0.0
- fancymenu/konkrete/melody: updated to MC 26.2 versions